### PR TITLE
Couple of edits after doing local install myself.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Mac OS system files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -8,19 +8,27 @@ The book and slides have been created using [Quarto](https://quarto.org/). In or
 
 To executre the Python code used in the book requires several Python packages. This repository includes a conda environment with all the necessary pacakges. To set up this environment use the following terminal commands
 
-```conda env create -f environment.yml```
+```
+conda env create -f environment.yml
+```
 
-```conda activate ds701_dev_env```
+```
+conda activate ds701_dev_env
+```
 
 ## Building the book
 
 To build the book you need to be in the `ds701_book` directory. Since the book is many chapters you need to set the following environment variable using the terminal command:
 
-```export QUARTO_DENO_EXTRA_OPTIONS=--v8-flags=--stack-size=8192```
+```
+export QUARTO_DENO_EXTRA_OPTIONS=--v8-flags=--stack-size=8192
+```
 
 Once this environment variable has been set you can render the entirebook using the terminal command:
 
-```quarto render .```
+```
+quarto render .
+```
 
 The html files are all located in the `_books` directory. The `_books` directory is not committed in the repository.
 

--- a/environment.yml
+++ b/environment.yml
@@ -259,7 +259,7 @@ dependencies:
       - pybtex==0.24.0
       - pybtex-docutils==1.0.3
       - pydata-sphinx-theme==0.15.4
-      - python-graphviz==0.20.3
+      - graphviz==0.20.3
       - rise==5.7.1
       - snowballstemmer==2.2.0
       - sphinx==7.3.7


### PR DESCRIPTION
Putting code block backticks on separate lines enables the copy icon when displayed in GitHub.