### PR TITLE
Python venv with pip requirements and updated GH Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
-      - run: conda env create -f environment.yml
-      - run: conda activate ds701_dev_env
+      - run: pip install jupyter
+      - run: pip install -r requirements.txt
 
       - name: Render and Publish
         uses: quarto-dev/quarto-actions/publish@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# virtual environment folders
+.venv/
+venv/
+env/
+ENV/
+
+# MacOS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The book and slides have been created using [Quarto](https://quarto.org/). In or
 
 To execute the Python code used in the book requires several Python packages. 
 
-This repository includes a conda environment with all the necessary pacakges. To set up this environment use the following terminal commands
+This repository includes a `venv` environment with all the necessary pacakges. To set up this environment use the following terminal commands
 
 ```sh
 python3 -m venv .venv
@@ -23,6 +23,8 @@ pip install -r requirements.txt
 
 > Deprecating the conda environment in favor of pip with a newer version of python and 
 > perhaps better GitHub actions support.
+
+This repository includes a conda environment with all the necessary packages. To set up this environment use the following terminal commands
 
 ```sh
 conda env create -f environment.yml

--- a/README.md
+++ b/README.md
@@ -6,21 +6,56 @@ The book and slides have been created using [Quarto](https://quarto.org/). In or
 
 ## Python environment
 
-To executre the Python code used in the book requires several Python packages. This repository includes a conda environment with all the necessary pacakges. To set up this environment use the following terminal commands
+> Tested on MacOS Sonoma 14.5 with python 3.12.4.
 
-```conda env create -f environment.yml```
+To execute the Python code used in the book requires several Python packages. 
 
-```conda activate ds701_dev_env```
+This repository includes a conda environment with all the necessary pacakges. To set up this environment use the following terminal commands
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### Conda environment (deprecated)
+
+> Deprecating the conda environment in favor of pip with a newer version of python and 
+> perhaps better GitHub actions support.
+
+```sh
+conda env create -f environment.yml
+```
+
+```sh
+conda activate ds701_dev_env
+```
 
 ## Building the book
 
+> Tested with Quarto 1.5.55 on MacOS Sonoma 14.5.
+
 To build the book you need to be in the `ds701_book` directory. Since the book is many chapters you need to set the following environment variable using the terminal command:
 
-```export QUARTO_DENO_EXTRA_OPTIONS=--v8-flags=--stack-size=8192```
+```
+export QUARTO_DENO_EXTRA_OPTIONS=--v8-flags=--stack-size=8192
+```
 
-Once this environment variable has been set you can render the entirebook using the terminal command:
+If the render gives a DENO error with the above environment variable, try
 
-```quarto render .```
+```sh
+export QUARTO_DENO_EXTRA_OPTIONS=
+
+export QUARTO_DENO_V8_OPTIONS=--stack-size=8192
+```
+
+Once this environment variable has been set you can render the entirebook using the terminal commands:
+
+```sh
+cd ds701_book
+quarto render .
+```
 
 The html files are all located in the `_books` directory. The `_books` directory is not committed in the repository.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,39 @@
+# Full install for Jupyter Notebooks
+jupyter
+
+# Used initially by Quarto to read configuration yml
+pyyaml
+
+# 01-Intro-to-Python
+matplotlib
+pandas
+
+# 02B-Pandas
+pandas_datareader
+setuptools
+seaborn
+yfinance
+scipy
+
+# 04-Linear-Algebra-Refresher
+qrcode
+
+# 06-Clustering-I-kmeans
+scikit-learn
+
+# 11-Dimensionality-Reduction-SVD-II
+nltk
+
+# 15-Classification-II-kNN
+pydotplus
+
+# 17-Regression-I-Linear
+statsmodels
+
+# 23-NN-I-Gradient-Descent
+networkx
+
+#24-NN-II-Backprop
+graphviz
+torch
+torchvision


### PR DESCRIPTION
Created requirements.txt file for a venv based python virtual environment with latest python version.

The requirements.txt file lists only the minimal parent packages that are needed to successfully render the entire book. I find this to be less brittle than listing every dependent package as well.

Updated the README to with the pip venv instructions.  I also added an alternate environment variable definition since the current one gave an error. It could be some change with the latest Quarto version (1.5.55). Not sure.

I then edited the GT publish action to exactly follow the script in the Quarto doc to hopefully build the book on a GH runner and publish to GH Pages.