### PR TITLE
Fix paths broken by the repo reorganization

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,19 +62,19 @@ jobs:
       - name: Render Quarto Project
         uses: quarto-dev/quarto-actions/render@v2
         with:
-          path: ./ds701_book
+          path: .
         env:
           QUARTO_DENO_V8_OPTIONS: --stack-size=8192
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./ds701_book/_site
+          path: ./_site
         
 #      - name: Render and Publish
 #        uses: quarto-dev/quarto-actions/publish@v2
 #        with:
-#          path: ./ds701_book
+#          path: .
 #          target: gh-pages
 #        env:
 #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/01-Intro-to-Python.qmd
+++ b/01-Intro-to-Python.qmd
@@ -4,7 +4,7 @@ jupyter: python3
 code-fold: false
 ---
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/01-Intro-to-Python.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/01-Intro-to-Python.ipynb)
 
 This chapter will not be covered in lecture. It's here to refresh the memory of those who haven't used Python in a while.
 

--- a/02B-Pandas.qmd
+++ b/02B-Pandas.qmd
@@ -7,7 +7,7 @@ code-fold: false
 ::: {.content-visible when-profile="web"}
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/02B-Pandas.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/02B-Pandas.ipynb)
 
 In this lecture we discuss one of most useful Python packages for data 
 science -- Pandas.

--- a/02C-Sklearn.qmd
+++ b/02C-Sklearn.qmd
@@ -7,7 +7,7 @@ code-fold: false
 ::: {.content-visible when-profile="web"}
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/02C-Sklearn.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/02C-Sklearn.ipynb)
 
 In this chapter we discuss another important Python package, Scikit-Learn (sklearn).
 :::

--- a/03-Probability-and-Statistics-Refresher.qmd
+++ b/03-Probability-and-Statistics-Refresher.qmd
@@ -5,7 +5,7 @@ jupyter: python3
 
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/03-Probability-and-Statistics-Refresher.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/03-Probability-and-Statistics-Refresher.ipynb)
 
 ```{python}
 #| echo: false

--- a/04-Linear-Algebra-Refresher.qmd
+++ b/04-Linear-Algebra-Refresher.qmd
@@ -7,7 +7,7 @@ jupyter: python3
 
 ## Introduction to linear algebra
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/04-Linear-Algebra-Refresher.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/04-Linear-Algebra-Refresher.ipynb)
 
 Linear algebra is the branch of mathematics involving vectors and matrices. In particular, how vectors are transformed.  Knowledge of linear algebra is essential in data science. 
 

--- a/05-Distances-Timeseries.qmd
+++ b/05-Distances-Timeseries.qmd
@@ -3,7 +3,7 @@ title: Distances and Time Series
 jupyter: python3
 ---
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/05-Distances-Timeseries.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/05-Distances-Timeseries.ipynb)
 
 We will start building some tools for making comparisons of data objects with particular attention to time series.
 

--- a/06-Clustering-I-kmeans.qmd
+++ b/06-Clustering-I-kmeans.qmd
@@ -16,7 +16,7 @@ import seaborn as sns
 
 ## 1854 Cholera Outbreak
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/06-Clustering-I-kmeans.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/06-Clustering-I-kmeans.ipynb)
 
 :::: {.columns }
 

--- a/07-Clustering-II-in-practice.qmd
+++ b/07-Clustering-II-in-practice.qmd
@@ -5,7 +5,7 @@ jupyter: python3
 
 ## Clustering in Practice
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/07-Clustering-II-in-practice.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/07-Clustering-II-in-practice.ipynb)
 
 
 ...featuring $k$-means

--- a/08-Clustering-III-hierarchical.qmd
+++ b/08-Clustering-III-hierarchical.qmd
@@ -6,7 +6,7 @@ fig-align: center
 
 ## Moving away from strict partitions
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/08-Clustering-III-hierarchical.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/08-Clustering-III-hierarchical.ipynb)
 
 ```{python}
 import numpy as np

--- a/09-Clustering-IV-GMM-EM.qmd
+++ b/09-Clustering-IV-GMM-EM.qmd
@@ -6,7 +6,7 @@ fig-align: center
 
 ## From Hard to Soft Clustering
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/09-Clustering-IV-GMM-EM.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/09-Clustering-IV-GMM-EM.ipynb)
 
 ```{python}
 #| echo: false

--- a/10-Low-Rank-and-SVD.qmd
+++ b/10-Low-Rank-and-SVD.qmd
@@ -5,7 +5,7 @@ jupyter: python3
 
 # Low Rank Approximations
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/10-Low-Rank-and-SVD.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/10-Low-Rank-and-SVD.ipynb)
 
 We now consider applications of the Singular Value Decomposition (SVD).
 

--- a/11-Dimensionality-Reduction-SVD-II.qmd
+++ b/11-Dimensionality-Reduction-SVD-II.qmd
@@ -6,7 +6,7 @@ nocite: |
   @novembre2008genes, @strang2022introduction
 ---
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/11-Dimensionality-Reduction-SVD-II.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/11-Dimensionality-Reduction-SVD-II.ipynb)
 
 We previously learned how to use the SVD as a tool for constructing low-rank matrices.
 
@@ -1060,6 +1060,6 @@ This asymmetry is what makes t-SNE effective!
 
 ## In-Class Exercise: Dimensionality Reduction with PCA and t-SNE
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/class_activity_notebooks/11-InClass-Exercise-Dimensionality-Reduction.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/class_activity_notebooks/11-InClass-Exercise-Dimensionality-Reduction.ipynb)
 
 ---

--- a/12-Anomaly-Detection-SVD-III.qmd
+++ b/12-Anomaly-Detection-SVD-III.qmd
@@ -3,7 +3,7 @@ title: Anomaly Detection (and SVD-III)
 jupyter: python3
 ---
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/12-Anomaly-Detection-SVD-III.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/12-Anomaly-Detection-SVD-III.ipynb)
 
 ```{python}
 #| hide_input: true

--- a/13-Learning-From-Data.qmd
+++ b/13-Learning-From-Data.qmd
@@ -5,7 +5,7 @@ jupyter: python3
 
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/13-Learning-From-Data.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/13-Learning-From-Data.ipynb)
 
 ```{python}
 #| echo: false

--- a/14-Classification-I-Decision-Trees.qmd
+++ b/14-Classification-I-Decision-Trees.qmd
@@ -8,7 +8,7 @@ nocite: |
 
 ## Outline
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/14-Classification-I-Decision-Trees.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/14-Classification-I-Decision-Trees.ipynb)
 
 - Build a decision tree manually
 - Look at single and collective impurity measures

--- a/14-save-Classification-I-Decision-Trees.qmd
+++ b/14-save-Classification-I-Decision-Trees.qmd
@@ -5,7 +5,7 @@ jupyter: python3
 
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/14-Classification-I-Decision-Trees.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/14-Classification-I-Decision-Trees.ipynb)
 
 ```{python}
 #| hide_input: true

--- a/15-Classification-II-kNN.qmd
+++ b/15-Classification-II-kNN.qmd
@@ -6,7 +6,7 @@ fig-align: center
 
 ## Introduction 
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/15-Classification-II-kNN.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/15-Classification-II-kNN.ipynb)
 
 ```{python}
 #| echo: false

--- a/16-Classification-III-NB-SVM.qmd
+++ b/16-Classification-III-NB-SVM.qmd
@@ -4,7 +4,7 @@ jupyter: python3
 fig-align: center
 ---
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/16-Classification-III-NB-SVM.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/16-Classification-III-NB-SVM.ipynb)
 
 ```{python}
 #| echo: false

--- a/17-Regression-I-Linear.qmd
+++ b/17-Regression-I-Linear.qmd
@@ -7,7 +7,7 @@ jupyter: python3
 
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/17-Regression-I-Linear.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/17-Regression-I-Linear.ipynb)
 
 ```{python}
 #| echo: false

--- a/18-Regression-II-Logistic.qmd
+++ b/18-Regression-II-Logistic.qmd
@@ -5,7 +5,7 @@ jupyter: python3
 
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/18-Regression-II-Logistic.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/18-Regression-II-Logistic.ipynb)
 
 ```{python}
 #| echo: false

--- a/18A-decision-tree-regression.qmd
+++ b/18A-decision-tree-regression.qmd
@@ -7,7 +7,7 @@ jupyter: python3
 
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/18A-decision-tree-regression.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/18A-decision-tree-regression.ipynb)
 
 <!--
 AI-GENERATED CODE

--- a/18B-gradient-boosting-methods.qmd
+++ b/18B-gradient-boosting-methods.qmd
@@ -7,7 +7,7 @@ jupyter: python3
 
 # Gradient Boosting Methods: XGBoost, LightGBM, and CatBoost
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/18B-gradient-boosting-methods.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/18B-gradient-boosting-methods.ipynb)
 
 <!--
 AI-GENERATED CODE

--- a/19-Regression-III-More-Linear.qmd
+++ b/19-Regression-III-More-Linear.qmd
@@ -28,7 +28,7 @@ np.random.seed(9876789)
 ```
 # Overfitting
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/19-Regression-III-More-Linear.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/19-Regression-III-More-Linear.ipynb)
 
 We have referenced the concept of overfitting previously in our [decision tree](14-Classification-I-Decision-Trees.qmd) and [dimensionality reduction](11-Dimensionality-Reduction-SVD-II.qmd) lectures.
 

--- a/20-Recommender-Systems-I.qmd
+++ b/20-Recommender-Systems-I.qmd
@@ -8,7 +8,7 @@ bibliography: references.bib
 
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/20-Recommender-Systems-I.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/20-Recommender-Systems-I.ipynb)
 
 ```{python}
 #| echo: false

--- a/20-Recommender-Systems-II.qmd
+++ b/20-Recommender-Systems-II.qmd
@@ -7,7 +7,7 @@ bibliography: references.bib
 ## Introduction
 
 <!--
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/20-Recommender-Systems-II.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/20-Recommender-Systems-II.ipynb)
 -->
 
 :::: {.columns}

--- a/21-Networks-I.qmd
+++ b/21-Networks-I.qmd
@@ -4,7 +4,7 @@ jupyter: python3
 ---
 
 # Networks
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/21-Networks-I.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/21-Networks-I.ipynb)
 
 ```{python}
 #| echo: false

--- a/22-Networks-II-Centrality-Clustering.qmd
+++ b/22-Networks-II-Centrality-Clustering.qmd
@@ -20,7 +20,7 @@ import laUtilities as ut
 
 # Overview
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/22-Networks-II-Centrality-Clustering.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/22-Networks-II-Centrality-Clustering.ipynb)
 
 We previously introduced the concept of a graph to describe networks. To further analyze networks we will discuss network centrality and clustering.
 

--- a/23-NN-I-Gradient-Descent.qmd
+++ b/23-NN-I-Gradient-Descent.qmd
@@ -5,7 +5,7 @@ jupyter: python3
 
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/23-NN-I-Gradient-Descent.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/23-NN-I-Gradient-Descent.ipynb)
 
 ```{python}
 #| code-fold: true

--- a/24-NN-II-Backprop.qmd
+++ b/24-NN-II-Backprop.qmd
@@ -5,7 +5,7 @@ jupyter: python3
 
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/24-NN-II-Backprop.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/24-NN-II-Backprop.ipynb)
 
 ```{python}
 #| echo: false

--- a/25-NN-III-CNNs.qmd
+++ b/25-NN-III-CNNs.qmd
@@ -15,7 +15,7 @@ from IPython.display import Image, HTML
 
 ## Recap
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/25-NN-III-CNNs.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/25-NN-III-CNNs.ipynb)
 
 We have covered the following topics
 

--- a/26-TimeSeries.qmd
+++ b/26-TimeSeries.qmd
@@ -6,7 +6,7 @@ bibliography: references.bib
 
 ## Colab
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/26-TimeSeries.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/26-TimeSeries.ipynb)
 
 
 # Introduction to Time Series

--- a/27-RNN.qmd
+++ b/27-RNN.qmd
@@ -18,7 +18,7 @@ from torch.utils.data import DataLoader, Dataset
 from IPython.display import Image
 ```
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/27-RNN.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/27-RNN.ipynb)
 
 We introduce recurrent neural networks (RNNs) which is a neural network architecture used for machine learning on sequential data.
 

--- a/28-NLP-save.qmd
+++ b/28-NLP-save.qmd
@@ -4,7 +4,7 @@ jupyter: python3
 bibliography: references.bib
 ---
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/27-RNN.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/27-RNN.ipynb)
 
 Natural language processing (NLP) is a subfield of artificial intelligence that allows computers to understand, process, and manipulate human language.
 

--- a/28-NLP.qmd
+++ b/28-NLP.qmd
@@ -4,7 +4,7 @@ jupyter: python3
 bibliography: references.bib
 ---
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/28-NLP.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/28-NLP.ipynb)
 
 Natural language processing (NLP) is a subfield of artificial intelligence that allows computers to understand, process, and manipulate human language.
 

--- a/29-NN-IV-Scikit-Learn.qmd
+++ b/29-NN-IV-Scikit-Learn.qmd
@@ -5,7 +5,7 @@ jupyter: python3
 
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/29-NN-IV-Scikit-Learn.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/29-NN-IV-Scikit-Learn.ipynb)
 
 ```{python}
 #| code-fold: true

--- a/30-NN-consolidated.qmd
+++ b/30-NN-consolidated.qmd
@@ -5,7 +5,7 @@ jupyter: python3
 
 ## Introduction
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/30-NN-consolidated.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/30-NN-consolidated.ipynb)
 
 ```{python}
 #| code-fold: true

--- a/31-Causal-Inference-I.qmd
+++ b/31-Causal-Inference-I.qmd
@@ -4,7 +4,7 @@ jupyter: python3
 bibliography: references.bib
 ---
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/31-Causal-Inference-I.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/31-Causal-Inference-I.ipynb)
 
 So far in this course we have built tools that are very good at answering one kind of
 question: **given what I observe, what should I predict?** Clustering, regression,

--- a/32-Causal-Inference-II.qmd
+++ b/32-Causal-Inference-II.qmd
@@ -4,7 +4,7 @@ jupyter: python3
 bibliography: references.bib
 ---
 
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/32-Causal-Inference-II.ipynb)
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/32-Causal-Inference-II.ipynb)
 
 In [Causal Inference I](31-Causal-Inference-I.qmd) we saw that the naive difference in
 means equals the true effect *plus selection bias*, and that **randomization** removes that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+DS701 ("Tools for Data Science") course notes: a set of Quarto `.qmd` lecture files that render to **three different outputs from the same source** — a website, reveal.js slides, and (deprecated) a book. The published site is at https://tools4ds.github.io/DS701-Course-Notes/. There is no application code to run — the deliverable is rendered content.
+
+The Quarto project root is the **repository root**: the lecture `.qmd` files and the `_quarto-*.yml` configs live there, with `scripts/` (Python helper modules + build utilities), `jupyter_notebooks/`, `figs/`, `data/`, `drawio/`, and `lecture-graph/` as subdirectories. A leftover `ds701_book/` directory may exist locally but holds only git-ignored build artifacts — nothing under it is tracked.
+
+## Environment setup
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt   # also: pip install jupyter
+```
+
+Tested with Python 3.12 and Quarto 1.5.55. `requirements.txt` maps packages to the lecture that needs them — when adding a Python dependency in a `.qmd`, add it there with a comment naming the lecture (matching the existing convention).
+
+## Build / render commands
+
+All rendering runs from the **repository root**. Large renders need a bigger V8 stack:
+
+```sh
+export QUARTO_DENO_V8_OPTIONS=--stack-size=8192
+
+quarto render                              # website -> _site/ (default profile: web)
+quarto render --profile slides             # all slides -> _revealjs/
+quarto render 05-Distances-Timeseries.qmd --profile slides   # single lecture, slides
+quarto preview                             # live preview of the website
+```
+
+Outputs (`_site/`, `_revealjs/`, `_book/`) are all git-ignored and never committed.
+
+## Profiles and multi-output architecture
+
+This is the central concept to understand before editing content. `_quarto.yml` sets `profile.default: web`. Each profile pulls in its own config, which defines its own render list, output dir, and format:
+
+- `_quarto-web.yml` → website, `_site/`, `format: html`
+- `_quarto-slides.yml` → slides, `_revealjs/`, `format: revealjs`
+- `_quarto-book.yml` → book, `_book/` (**deprecated** — kept for PDF export)
+
+A single `.qmd` therefore feeds multiple outputs. Content is shown/hidden per output using Quarto conditional divs, which appear throughout the lectures:
+
+```
+::: {.content-visible when-profile="slides"}   # slides only
+::: {.content-hidden when-profile="slides"}     # everything except slides
+::: {.incremental}   ::: {.fragment}            # slide-only reveal animations
+```
+
+When you add or rename a `.qmd`, you must add it to the `render:` list **and** the sidebar `contents:` in the relevant `_quarto-*.yml` files — the lists are maintained by hand and are not identical across profiles (e.g. `12-Anomaly-Detection-SVD-III.qmd` is excluded from web but present in slides).
+
+`scripts/print_quarto_config.py` is a `pre-render` hook that merges and dumps the active config to `config_log.yml` for debugging what a profile actually resolves to.
+
+## Jupyter notebook generation (must stay in sync)
+
+`jupyter_notebooks/*.ipynb` are **generated from the `.qmd` files and committed** (they back the "Open in Colab" badges at the top of each lecture). Regenerate after editing any `.qmd` containing Python:
+
+```sh
+./cmd-cnvt-to-jupyter.sh    # from the repo root; converts only .qmd files newer than their .ipynb, commit the result
+```
+
+The list of converted files lives inside that script and is maintained separately from the profile render lists.
+
+## Slide stripping (for presentation)
+
+`scripts/strip-tags-with-profile.py` produces a `-stripped.qmd` with conditional-div wrappers resolved and `.fragment`/`.incremental` tags removed, for a cleaner presentation source:
+
+```sh
+./scripts/strip-tags-with-profile.py 11-Dimensionality-Reduction-SVD-II.qmd --profile slides
+```
+
+## Caching
+
+Both website and slides configs set `execute: freeze: auto` and `cache: true`. Rendered/executed outputs are frozen under `_freeze/` (committed) so CI and other machines don't re-execute unchanged code. If a code change isn't reflected after render, the freeze/cache is likely stale.
+
+## Deployment
+
+`.github/workflows/publish.yml` renders the `web` profile at the repo root on every push to `main` (installs Quarto, GraphViz, FFmpeg, Python deps) and deploys `_site` to GitHub Pages. Merging to `main` publishes.
+
+## Content conventions
+
+- Every lecture `.qmd` has YAML front matter with `title:` and `jupyter: python3`, followed by a Colab badge linking to its generated notebook.
+- Shared course URLs (Piazza, Gradescope, GitHub) live in `_variables.yml` and are referenced as Quarto variables — don't hardcode them.
+- BibTeX citations go in `references.bib`; enable per-file via `bibliography: references.bib` in front matter (not enabled globally).
+- Reusable Python for lectures lives in module files under `scripts/` (`laUtilities.py`, `slideUtilities.py`, `recommender_*.py`). Lectures import these as **top-level** modules (`import laUtilities as ut`), and `recommender_MF.py` imports its siblings the same way — see the `_environment` note below for how that resolves. Don't convert these to `from scripts.x import y`; it would break the intra-module imports.
+
+## The `_environment` file
+
+`_environment` at the repo root sets `PYTHONPATH=scripts` so the lectures' top-level imports of the helper modules resolve. Quarto applies it on every **project** render and passes it through to the Jupyter kernel.
+
+Caveat: `_environment` is a project-level feature. It applies to `quarto render` and to `quarto render <lecture>.qmd` run from the repo root (both are project renders), but is ignored if a `.qmd` is rendered outside the project.
+
+## Colab badge paths
+
+Badges point at `.../blob/main/jupyter_notebooks/<lecture>.ipynb` (or `class_activity_notebooks/` for in-class exercises) — no `ds701_book/` segment. The same badge is embedded in the generated `.ipynb`, so a path change has to be applied to both the `.qmd` and the committed notebook.
+
+Known dead badge: `12-Anomaly-Detection-SVD-III.qmd` links to a notebook that has never been generated — the lecture is excluded from the web profile and absent from `cmd-cnvt-to-jupyter.sh`, so the badge isn't reachable from the published site.
+
+## grading-utils/
+
+Separate, self-contained: `fa25-grading.ipynb` plus grade CSV/XLSX files for computing course grades. Unrelated to the book build.

--- a/README.md
+++ b/README.md
@@ -37,16 +37,25 @@ type:
 
 along with a base `_quarto.yml` configuration.
 
+## Repository Layout
+
+The Quarto project root is the repository root. The lecture `.qmd` files live
+there alongside the `_quarto-*.yml` configurations, with supporting content in
+subdirectories:
+
+* `scripts/` — Python helper modules used by the lectures (`laUtilities.py`,
+  `slideUtilities.py`, `recommender_*.py`) and build utilities
+  (`print_quarto_config.py`, `strip-tags-with-profile.py`)
+* `jupyter_notebooks/` — generated notebooks backing the *Open in Colab* badges
+* `figs/`, `data/`, `drawio/` — figures, datasets and diagram sources
+* `lecture-graph/` — lecture dependency graph visualization
+* `grading-utils/` — self-contained grade computation notebook and spreadsheets
 
 ## Building the Site Locally
 
 > Tested with Quarto 1.5.55 on MacOS Sonoma 14.5.
 
-To build the site you need to be in the `ds701_book` directory. 
-
-```sh
-cd ds701_book
-```
+All build commands are run from the repository root.
 
 Since the site contains many lectures you may need to set the following
 environment variable using the terminal command:
@@ -58,7 +67,7 @@ export QUARTO_DENO_V8_OPTIONS=--stack-size=8192
 Once this environment variable has been set you can render the entire site using the terminal commands:
 
 ```sh
-# From ds701_book/ dir
+# From the repository root
 quarto render
 ```
 
@@ -70,7 +79,7 @@ To preview and individual chapter using VSCode, open that chapter's qmd file in
 VSCode and run `Shift-Command-K` in the terminal or click on the preview icon
 on the upper right of the code window,.
 
-Alternatively you can run `quarto preview` from a terminal prompt in the `ds701_book` directory.
+Alternatively you can run `quarto preview` from a terminal prompt at the repository root.
 To exit preview, hit `Ctl-c` in the same terminal window.
 
 ## Rendering Slides
@@ -79,11 +88,11 @@ To render slides for each lecture run
 ```sh
 quarto render --profile slides
 ```
-from `ds701_book/`. The resulting slides are writtein to `_revealjs` which
+from the repository root. The resulting slides are writtein to `_revealjs` which
 is ignored by git.
 
 Any easy way to select slides to preview is to open the folder in a browser
-such as `file:///<path-to-project-parent-folder>/DS701-Course-Notes/ds701_book/_revealjs/`.
+such as `file:///<path-to-project-parent-folder>/DS701-Course-Notes/_revealjs/`.
 Then you can just click on one of the `.html` files to view the slides.
 
 You can render just one slide with a command like
@@ -96,7 +105,7 @@ quarto render 05-Distances-Timeseries.qmd --profile slides
 To strip the slides for presentation, run
 
 ```sh
-./strip-tags-with-profile.py 11-Dimensionality-Reduction-SVD-II.qmd --profile slides
+./scripts/strip-tags-with-profile.py 11-Dimensionality-Reduction-SVD-II.qmd --profile slides
 ```
 
 This will create a new file `11-Dimensionality-Reduction-SVD-II-stripped.qmd` in the same directory.
@@ -110,7 +119,7 @@ TODO: The script for jupyter notebook creation could run this first so all the d
 To create PDFs from the reveal.js slides, you can use
 [decktape](https://github.com/astefanutti/decktape).
 
-For example, from `ds701_book`, run
+For example, from the repository root, run
 
 ```bash
 decktape _revealjs/04-Linear-Algebra-Refresher.html 04-Linear-Algebra-Refresher.pdf
@@ -119,8 +128,8 @@ decktape _revealjs/04-Linear-Algebra-Refresher.html 04-Linear-Algebra-Refresher.
 ## Creating Jupyter Notebooks
 
 To create Jupyter notebook versions of each of the lecture
-notes, run `./cmd-cnvt-to-jupyter.sh` from the `ds701_book`
-folder. It renders the Jupyter notebooks into the `jupyter_notebooks` folder
+notes, run `./cmd-cnvt-to-jupyter.sh` from the repository
+root. It renders the Jupyter notebooks into the `jupyter_notebooks` folder
 if the associated .qmd file has been modified.
 
 > Whenever you change in any `.qmd` file that has python in it, re-run
@@ -145,7 +154,7 @@ we use Quarto's support for [citations](https://quarto.org/docs/authoring/citati
 in the BibTeX format.
 
 For bibtex citations, add entries to 
-[`ds701_book/references.bib`](./ds701_book/references.bib) and cite them as
+[`references.bib`](./references.bib) and cite them as
 directed Quarto [citations](https://quarto.org/docs/authoring/citations.html).
 
 As stated in the Quarto documentation, the list of works will be placed at the

--- a/_environment
+++ b/_environment
@@ -1,0 +1,5 @@
+# Environment variables applied by Quarto to every render of this project.
+# The lecture .qmd files import helper modules (laUtilities, slideUtilities,
+# recommender_*) as top-level modules, but those modules live in scripts/.
+# Putting scripts/ on PYTHONPATH keeps those imports resolvable.
+PYTHONPATH=scripts

--- a/class_activity_notebooks/11-InClass-Exercise-Dimensionality-Reduction.ipynb
+++ b/class_activity_notebooks/11-InClass-Exercise-Dimensionality-Reduction.ipynb
@@ -6,7 +6,7 @@
       "source": [
         "# In-Class Exercise: Dimensionality Reduction with PCA and t-SNE\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/class_activity_notebooks/11-InClass-Exercise-Dimensionality-Reduction.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/class_activity_notebooks/11-InClass-Exercise-Dimensionality-Reduction.ipynb)\n",
         "\n",
         "**Time: 10 minutes**\n",
         "\n",

--- a/jupyter_notebooks/01-Intro-to-Python.ipynb
+++ b/jupyter_notebooks/01-Intro-to-Python.ipynb
@@ -10,7 +10,7 @@
         "code-fold: false\n",
         "---\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/01-Intro-to-Python.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/01-Intro-to-Python.ipynb)\n",
         "\n",
         "This chapter will not be covered in lecture. It's here to refresh the memory of those who haven't used Python in a while.\n",
         "\n",

--- a/jupyter_notebooks/02B-Pandas.ipynb
+++ b/jupyter_notebooks/02B-Pandas.ipynb
@@ -13,7 +13,7 @@
         "::: {.content-visible when-profile=\"web\"}\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/02B-Pandas.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/02B-Pandas.ipynb)\n",
         "\n",
         "In this lecture we discuss one of most useful Python packages for data \n",
         "science -- Pandas.\n",

--- a/jupyter_notebooks/02C-Sklearn.ipynb
+++ b/jupyter_notebooks/02C-Sklearn.ipynb
@@ -13,7 +13,7 @@
         "::: {.content-visible when-profile=\"web\"}\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/02C-Sklearn.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/02C-Sklearn.ipynb)\n",
         "\n",
         "In this chapter we discuss another important Python package, Scikit-Learn (sklearn).\n",
         ":::\n",

--- a/jupyter_notebooks/03-Probability-and-Statistics-Refresher.ipynb
+++ b/jupyter_notebooks/03-Probability-and-Statistics-Refresher.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/03-Probability-and-Statistics-Refresher.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/03-Probability-and-Statistics-Refresher.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/04-Linear-Algebra-Refresher.ipynb
+++ b/jupyter_notebooks/04-Linear-Algebra-Refresher.ipynb
@@ -13,7 +13,7 @@
         "\n",
         "## Introduction to linear algebra\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/04-Linear-Algebra-Refresher.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/04-Linear-Algebra-Refresher.ipynb)\n",
         "\n",
         "Linear algebra is the branch of mathematics involving vectors and matrices. In particular, how vectors are transformed.  Knowledge of linear algebra is essential in data science. \n",
         "\n",

--- a/jupyter_notebooks/05-Distances-Timeseries.ipynb
+++ b/jupyter_notebooks/05-Distances-Timeseries.ipynb
@@ -9,7 +9,7 @@
         "jupyter: python3\n",
         "---\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/05-Distances-Timeseries.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/05-Distances-Timeseries.ipynb)\n",
         "\n",
         "We will start building some tools for making comparisons of data objects with particular attention to time series.\n",
         "\n",

--- a/jupyter_notebooks/06-Clustering-I-kmeans.ipynb
+++ b/jupyter_notebooks/06-Clustering-I-kmeans.ipynb
@@ -32,7 +32,7 @@
         "\n",
         "## 1854 Cholera Outbreak\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/06-Clustering-I-kmeans.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/06-Clustering-I-kmeans.ipynb)\n",
         "\n",
         ":::: {.columns }\n",
         "\n",

--- a/jupyter_notebooks/07-Clustering-II-in-practice.ipynb
+++ b/jupyter_notebooks/07-Clustering-II-in-practice.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "## Clustering in Practice\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/07-Clustering-II-in-practice.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/07-Clustering-II-in-practice.ipynb)\n",
         "\n",
         "\n",
         "...featuring $k$-means\n",

--- a/jupyter_notebooks/08-Clustering-III-hierarchical.ipynb
+++ b/jupyter_notebooks/08-Clustering-III-hierarchical.ipynb
@@ -12,7 +12,7 @@
         "\n",
         "## Moving away from strict partitions\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/08-Clustering-III-hierarchical.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/08-Clustering-III-hierarchical.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/09-Clustering-IV-GMM-EM.ipynb
+++ b/jupyter_notebooks/09-Clustering-IV-GMM-EM.ipynb
@@ -12,7 +12,7 @@
         "\n",
         "## From Hard to Soft Clustering\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/09-Clustering-IV-GMM-EM.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/09-Clustering-IV-GMM-EM.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/10-Low-Rank-and-SVD.ipynb
+++ b/jupyter_notebooks/10-Low-Rank-and-SVD.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "# Low Rank Approximations\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/10-Low-Rank-and-SVD.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/10-Low-Rank-and-SVD.ipynb)\n",
         "\n",
         "We now consider applications of the Singular Value Decomposition (SVD).\n",
         "\n",

--- a/jupyter_notebooks/11-Dimensionality-Reduction-SVD-II.ipynb
+++ b/jupyter_notebooks/11-Dimensionality-Reduction-SVD-II.ipynb
@@ -12,7 +12,7 @@
         "  @novembre2008genes, @strang2022introduction\n",
         "---\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/11-Dimensionality-Reduction-SVD-II.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/11-Dimensionality-Reduction-SVD-II.ipynb)\n",
         "\n",
         "We previously learned how to use the SVD as a tool for constructing low-rank matrices.\n",
         "\n",

--- a/jupyter_notebooks/13-Learning-From-Data.ipynb
+++ b/jupyter_notebooks/13-Learning-From-Data.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/13-Learning-From-Data.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/13-Learning-From-Data.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/14-Classification-I-Decision-Trees.ipynb
+++ b/jupyter_notebooks/14-Classification-I-Decision-Trees.ipynb
@@ -14,7 +14,7 @@
         "\n",
         "## Outline\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/14-Classification-I-Decision-Trees.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/14-Classification-I-Decision-Trees.ipynb)\n",
         "\n",
         "- Build a decision tree manually\n",
         "- Look at single and collective impurity measures\n",

--- a/jupyter_notebooks/15-Classification-II-kNN.ipynb
+++ b/jupyter_notebooks/15-Classification-II-kNN.ipynb
@@ -12,7 +12,7 @@
         "\n",
         "## Introduction \n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/15-Classification-II-kNN.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/15-Classification-II-kNN.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/16-Classification-III-NB-SVM.ipynb
+++ b/jupyter_notebooks/16-Classification-III-NB-SVM.ipynb
@@ -10,7 +10,7 @@
         "fig-align: center\n",
         "---\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/16-Classification-III-NB-SVM.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/16-Classification-III-NB-SVM.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/17-Regression-I-Linear.ipynb
+++ b/jupyter_notebooks/17-Regression-I-Linear.ipynb
@@ -13,7 +13,7 @@
         "\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/17-Regression-I-Linear.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/17-Regression-I-Linear.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/18-Regression-II-Logistic.ipynb
+++ b/jupyter_notebooks/18-Regression-II-Logistic.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/18-Regression-II-Logistic.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/18-Regression-II-Logistic.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/19-Regression-III-More-Linear.ipynb
+++ b/jupyter_notebooks/19-Regression-III-More-Linear.ipynb
@@ -45,7 +45,7 @@
       "source": [
         "# Overfitting\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/19-Regression-III-More-Linear.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/19-Regression-III-More-Linear.ipynb)\n",
         "\n",
         "We have referenced the concept of overfitting previously in our [decision tree](14-Classification-I-Decision-Trees.qmd) and [dimensionality reduction](11-Dimensionality-Reduction-SVD-II.qmd) lectures.\n",
         "\n",

--- a/jupyter_notebooks/20-Recommender-Systems-I.ipynb
+++ b/jupyter_notebooks/20-Recommender-Systems-I.ipynb
@@ -14,7 +14,7 @@
         "\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/20-Recommender-Systems-I.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/20-Recommender-Systems-I.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/20-Recommender-Systems-II.ipynb
+++ b/jupyter_notebooks/20-Recommender-Systems-II.ipynb
@@ -13,7 +13,7 @@
         "## Introduction\n",
         "\n",
         "<!--\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/20-Recommender-Systems-II.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/20-Recommender-Systems-II.ipynb)\n",
         "-->\n",
         "\n",
         ":::: {.columns}\n",

--- a/jupyter_notebooks/20-Recommender-Systems.ipynb
+++ b/jupyter_notebooks/20-Recommender-Systems.ipynb
@@ -14,7 +14,7 @@
         "\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/20-Recommender-Systems.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/20-Recommender-Systems.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/21-Networks-I.ipynb
+++ b/jupyter_notebooks/21-Networks-I.ipynb
@@ -10,7 +10,7 @@
         "---\n",
         "\n",
         "# Networks\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/21-Networks-I.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/21-Networks-I.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/22-Networks-II-Centrality-Clustering.ipynb
+++ b/jupyter_notebooks/22-Networks-II-Centrality-Clustering.ipynb
@@ -36,7 +36,7 @@
       "source": [
         "# Overview\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/22-Networks-II-Centrality-Clustering.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/22-Networks-II-Centrality-Clustering.ipynb)\n",
         "\n",
         "We previously introduced the concept of a graph to describe networks. To further analyze networks we will discuss network centrality and clustering.\n",
         "\n",

--- a/jupyter_notebooks/23-NN-I-Gradient-Descent.ipynb
+++ b/jupyter_notebooks/23-NN-I-Gradient-Descent.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/23-NN-I-Gradient-Descent.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/23-NN-I-Gradient-Descent.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/24-NN-II-Backprop.ipynb
+++ b/jupyter_notebooks/24-NN-II-Backprop.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/24-NN-II-Backprop.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/24-NN-II-Backprop.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/25-NN-III-CNNs.ipynb
+++ b/jupyter_notebooks/25-NN-III-CNNs.ipynb
@@ -30,7 +30,7 @@
       "source": [
         "## Recap\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/25-NN-III-CNNs.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/25-NN-III-CNNs.ipynb)\n",
         "\n",
         "We have covered the following topics\n",
         "\n",

--- a/jupyter_notebooks/26-TimeSeries.ipynb
+++ b/jupyter_notebooks/26-TimeSeries.ipynb
@@ -12,7 +12,7 @@
         "\n",
         "## Colab\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/26-TimeSeries.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/26-TimeSeries.ipynb)\n",
         "\n",
         "\n",
         "# Introduction to Time Series\n",

--- a/jupyter_notebooks/27-RNN.ipynb
+++ b/jupyter_notebooks/27-RNN.ipynb
@@ -34,7 +34,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/27-RNN.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/27-RNN.ipynb)\n",
         "\n",
         "We introduce recurrent neural networks (RNNs) which is a neural network architecture used for machine learning on sequential data.\n",
         "\n",

--- a/jupyter_notebooks/28-NLP.ipynb
+++ b/jupyter_notebooks/28-NLP.ipynb
@@ -10,7 +10,7 @@
         "bibliography: references.bib\n",
         "---\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/28-NLP.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/28-NLP.ipynb)\n",
         "\n",
         "Natural language processing (NLP) is a subfield of artificial intelligence that allows computers to understand, process, and manipulate human language.\n",
         "\n",

--- a/jupyter_notebooks/29-NN-IV-Scikit-Learn.ipynb
+++ b/jupyter_notebooks/29-NN-IV-Scikit-Learn.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/29-NN-IV-Scikit-Learn.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/29-NN-IV-Scikit-Learn.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/30-NN-consolidated.ipynb
+++ b/jupyter_notebooks/30-NN-consolidated.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "## Introduction\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/30-NN-consolidated.ipynb)"
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/30-NN-consolidated.ipynb)"
       ]
     },
     {

--- a/jupyter_notebooks/31-Causal-Inference-I.ipynb
+++ b/jupyter_notebooks/31-Causal-Inference-I.ipynb
@@ -10,7 +10,7 @@
         "bibliography: references.bib\n",
         "---\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/31-Causal-Inference-I.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/31-Causal-Inference-I.ipynb)\n",
         "\n",
         "So far in this course we have built tools that are very good at answering one kind of\n",
         "question: **given what I observe, what should I predict?** Clustering, regression,\n",

--- a/jupyter_notebooks/32-Causal-Inference-II.ipynb
+++ b/jupyter_notebooks/32-Causal-Inference-II.ipynb
@@ -10,7 +10,7 @@
         "bibliography: references.bib\n",
         "---\n",
         "\n",
-        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/ds701_book/jupyter_notebooks/32-Causal-Inference-II.ipynb)\n",
+        "[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tools4ds/DS701-Course-Notes/blob/main/jupyter_notebooks/32-Causal-Inference-II.ipynb)\n",
         "\n",
         "In [Causal Inference I](31-Causal-Inference-I.qmd) we saw that the naive difference in\n",
         "means equals the true effect *plus selection bias*, and that **randomization** removes that\n",


### PR DESCRIPTION
The reorg moved the Quarto project from `ds701_book/` up to the repo root and relocated the Python helper modules into `scripts/`. Several path references were missed.

## CI publishing (site is currently unpublishable)

`publish.yml` rendered `./ds701_book` and uploaded `./ds701_book/_site` — neither path exists any more. Both now point at the repo root.

## Lecture helper imports

Lectures do `import laUtilities as ut` (also `slideUtilities`, `recommender_MF`) as **top-level** modules, but those moved to `scripts/` with nothing adding it to `sys.path`. Confirmed broken: `python3 -c "import laUtilities"` → `ModuleNotFoundError`.

This is currently masked by the committed `_freeze/` cache — CI stays green until someone edits one of the 8 affected lectures, at which point the render fails.

Fixed with a new `_environment` file at the repo root setting `PYTHONPATH=scripts`. Quarto applies it on project renders and passes it to the Jupyter kernel.

Why a path fix rather than rewriting to `from scripts.x import y`: `scripts/recommender_MF.py` imports `recommender_als` and `recommender_lmafit` as top-level modules itself, so a package-style rewrite would need edits inside the modules too.

## Colab badges (37 dead links on the live site)

Badges pointed at `blob/main/ds701_book/...`, which no longer resolves. Stripped the segment from the `.qmd` files **and** the committed `.ipynb` files, which embed the same badge — otherwise the next `cmd-cnvt-to-jupyter.sh` run would reintroduce stale URLs.

`14-Classification-I-Decision-Trees` pointed at a bare `ds701_book/<name>.ipynb` and was already wrong pre-reorg; retargeted to `jupyter_notebooks/`.

## Docs

`README.md` and `CLAUDE.md` still said `cd ds701_book` for every build/preview/conversion command and referenced `strip-tags-with-profile.py` at its old location. Added a repo-layout section to the README.

## Verification

- Rendered a probe `.qmd` in this repo exercising the real imports: `IMPORTS_OK scripts slideUtilities recommender_MF`, no tracebacks. `ut.__file__` resolving under `scripts/` confirms the new path is doing the work. Probe removed.
- Separately confirmed in a scratch project that `_environment` is a *project-level* feature — it applies to `quarto render` and `quarto render <lecture>.qmd` from the repo root, but is ignored for a `.qmd` rendered outside a project. Both documented paths are covered.
- Every Colab badge target verified to exist in the tree, with one exception (below).
- Content diff is badge-only: 74 insertions / 74 deletions across `.qmd` + `.ipynb`, zero changed lines without a badge URL.

## Not addressed

`12-Anomaly-Detection-SVD-III.qmd`'s badge points at a notebook that has never been generated — the lecture is excluded from the web profile and absent from `cmd-cnvt-to-jupyter.sh`. Pre-existing and not reachable from the published site; fixing it means deciding whether that lecture should be converted at all. Documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)